### PR TITLE
first translations

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Neu ankommende Protokolleinträge werden gesammelt und regelmäßig in die Datenpunkte geschrieben. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Hinweis: Die Datenpunkte werden nur geschrieben, wenn eine Änderung vorgenommen wurde. ",
+    "Seconds": "Sekunden",
+    "Update-Interval: Update data points": "Update-Intervall: Aktualisieren Sie Datenpunkte",
+    "logparser adapter settings": "Adaptereinstellungen für logparser"
+}

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.",
+    "Seconds": "Seconds",
+    "Update-Interval: Update data points": "Update-Interval: Update data points",
+    "logparser adapter settings": "Adapter settings for logparser"
+}

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Las entradas de registro recién llegadas se recopilan y se escriben regularmente en los puntos de datos. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Nota: Los puntos de datos solo se escriben si ha habido un cambio. ",
+    "Seconds": "Segundos",
+    "Update-Interval: Update data points": "Actualizar-Intervalo: actualizar puntos de datos",
+    "logparser adapter settings": "Ajustes del adaptador para logparser"
+}

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Les entrées de journal nouvellement arrivées sont collectées et régulièrement écrites dans les points de données. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Remarque: Les points de données ne sont écrits qu'en cas de modification. ",
+    "Seconds": "Secondes",
+    "Update-Interval: Update data points": "Update-Interval: Mettre à jour les points de données",
+    "logparser adapter settings": "Paramètres d'adaptateur pour logparser"
+}

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Le voci di registro appena arrivate vengono raccolte e scritte regolarmente nei punti dati. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Nota: i punti dati vengono scritti solo se è stata apportata una modifica. ",
+    "Seconds": "secondi",
+    "Update-Interval: Update data points": "Update-Interval: aggiorna i punti dati",
+    "logparser adapter settings": "Impostazioni dell'adattatore per logparser"
+}

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Nieuw binnengekomen logboekvermeldingen worden verzameld en regelmatig naar de gegevenspunten geschreven. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Opmerking: de gegevenspunten worden alleen geschreven als er een wijziging is aangebracht. ",
+    "Seconds": "Seconden",
+    "Update-Interval: Update data points": "Update-interval: gegevenspunten bijwerken",
+    "logparser adapter settings": "Adapterinstellingen voor logparser"
+}

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Nowo przybyłe wpisy dziennika są gromadzone i regularnie zapisywane w punktach danych. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Uwaga: Punkty danych są zapisywane tylko wtedy, gdy nastąpiła zmiana. ",
+    "Seconds": "sekundy",
+    "Update-Interval: Update data points": "Interwał aktualizacji: aktualizuj punkty danych",
+    "logparser adapter settings": "Ustawienia adaptera dla logparser"
+}

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "As entradas de log que chegam recentemente são coletadas e gravadas regularmente nos pontos de dados. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Nota: Os pontos de dados são gravados apenas se houver uma alteração. ",
+    "Seconds": "Segundos",
+    "Update-Interval: Update data points": "Intervalo de atualização: atualiza pontos de dados",
+    "logparser adapter settings": "Configurações do adaptador para logparser"
+}

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "Вновь поступающие записи журнала собираются и регулярно записываются в точки данных. ",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "Примечание. Точки данных записываются только в том случае, если произошли изменения. ",
+    "Seconds": "секунд",
+    "Update-Interval: Update data points": "Интервал обновления: обновление точек данных",
+    "logparser adapter settings": "Настройки адаптера для logparser"
+}

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -1,0 +1,7 @@
+{
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": "收集新到达的日志条目并将其定期写入数据点。",
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": "注意：仅在发生更改时才写入数据点。",
+    "Seconds": "秒",
+    "Update-Interval: Update data points": "更新间隔：更新数据点",
+    "logparser adapter settings": "logparser的适配器设置"
+}

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -293,13 +293,13 @@
                 <!-- Section "Update Interval" -->
                 <div class="row">
                     <div class="col s12">
-                        <p class="translate title">Update-Intervall: Datenpunkte aktualisieren</p>
-                        <p class="translate info">Neu reinkommende Logeinträge werden gesammelt und regelmäßig in die Datenpunkte geschrieben. Default ist 10 Sekunden.</p>
-                        <p class="translate info">Hinweis: Die Datenpunkte werden nur geschrieben, falls es eine Änderung gab. Dennoch ist es aus Performance-Sicht nicht sinnvoll, hier ein zu kurzes Intervall einzustellen. Kleiner als 2 Sekunden ist nicht erlaubt.</p>
+                        <p class="translate title">Update-Interval: Update data points</p>
+                        <p class="translate info">Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.</p>
+                        <p class="translate info">Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.</p>
                         <div class="input-field col s12 m6">
                             <input class="value validate" placeholder="10" id="updateInterval" type="number" min="2" max="10000">
                             <label for="updateInterval" class="translate">Update Interval</label>
-                            <span class="helper-text translate">Sekunden</span>
+                            <span class="helper-text translate">Seconds</span>
                         </div>
 
 

--- a/admin/words.js
+++ b/admin/words.js
@@ -2,40 +2,9 @@
 'use strict';
 
 systemDictionary = {
-    'logparser adapter settings': {
-        'en': 'Adapter settings for logparser',
-        'de': 'Adaptereinstellungen für logparser',
-        'ru': 'Настройки адаптера для logparser',
-        'pt': 'Configurações do adaptador para logparser',
-        'nl': 'Adapterinstellingen voor logparser',
-        'fr': "Paramètres d'adaptateur pour logparser",
-        'it': "Impostazioni dell'adattatore per logparser",
-        'es': 'Ajustes del adaptador para logparser',
-        'pl': 'Ustawienia adaptera dla logparser',
-        'zh-cn': 'logparser的适配器设置'
-    },
-    'option1': {
-        'en': 'option1',
-        'de': 'option1',
-        'ru': 'option1',
-        'pt': 'option1',
-        'nl': 'option1',
-        'fr': 'option1',
-        'it': 'option1',
-        'es': 'option1',
-        'pl': 'option1',
-        'zh-cn': 'option1'
-    },
-    'option2': {
-        'en': 'option2',
-        'de': 'option2',
-        'ru': 'option2',
-        'pt': 'option2',
-        'nl': 'option2',
-        'fr': 'option2',
-        'it': 'option2',
-        'es': 'option2',
-        'pl': 'option2',
-        'zh-cn': 'option2'
-    }
+    "logparser adapter settings": {                  "en": "Adapter settings for logparser",                  "de": "Adaptereinstellungen für logparser",              "ru": "Настройки адаптера для logparser",                "pt": "Configurações do adaptador para logparser",       "nl": "Adapterinstellingen voor logparser",              "fr": "Paramètres d'adaptateur pour logparser",          "it": "Impostazioni dell'adattatore per logparser",      "es": "Ajustes del adaptador para logparser",            "pl": "Ustawienia adaptera dla logparser",               "zh-cn": "logparser的适配器设置"},
+    "Update-Interval: Update data points": {         "en": "Update-Interval: Update data points",             "de": "Update-Intervall: Aktualisieren Sie Datenpunkte", "ru": "Интервал обновления: обновление точек данных",    "pt": "Intervalo de atualização: atualiza pontos de dados", "nl": "Update-interval: gegevenspunten bijwerken",       "fr": "Update-Interval: Mettre à jour les points de données", "it": "Update-Interval: aggiorna i punti dati",          "es": "Actualizar-Intervalo: actualizar puntos de datos", "pl": "Interwał aktualizacji: aktualizuj punkty danych", "zh-cn": "更新间隔：更新数据点"},
+    "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.": {"en": "Newly arriving log entries are collected and regularly written to the data points. The default is 10 seconds.", "de": "Neu ankommende Protokolleinträge werden gesammelt und regelmäßig in die Datenpunkte geschrieben. ", "ru": "Вновь поступающие записи журнала собираются и регулярно записываются в точки данных. ", "pt": "As entradas de log que chegam recentemente são coletadas e gravadas regularmente nos pontos de dados. ", "nl": "Nieuw binnengekomen logboekvermeldingen worden verzameld en regelmatig naar de gegevenspunten geschreven. ", "fr": "Les entrées de journal nouvellement arrivées sont collectées et régulièrement écrites dans les points de données. ", "it": "Le voci di registro appena arrivate vengono raccolte e scritte regolarmente nei punti dati. ", "es": "Las entradas de registro recién llegadas se recopilan y se escriben regularmente en los puntos de datos. ", "pl": "Nowo przybyłe wpisy dziennika są gromadzone i regularnie zapisywane w punktach danych. ", "zh-cn": "收集新到达的日志条目并将其定期写入数据点。"},
+    "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.": {"en": "Note: The data points are only written if there has been a change. Nevertheless, from a performance point of view, it does not make sense to set an interval that is too short. Less than 2 seconds is not allowed.", "de": "Hinweis: Die Datenpunkte werden nur geschrieben, wenn eine Änderung vorgenommen wurde. ", "ru": "Примечание. Точки данных записываются только в том случае, если произошли изменения. ", "pt": "Nota: Os pontos de dados são gravados apenas se houver uma alteração. ", "nl": "Opmerking: de gegevenspunten worden alleen geschreven als er een wijziging is aangebracht. ", "fr": "Remarque: Les points de données ne sont écrits qu'en cas de modification. ", "it": "Nota: i punti dati vengono scritti solo se è stata apportata una modifica. ", "es": "Nota: Los puntos de datos solo se escriben si ha habido un cambio. ", "pl": "Uwaga: Punkty danych są zapisywane tylko wtedy, gdy nastąpiła zmiana. ", "zh-cn": "注意：仅在发生更改时才写入数据点。"},
+    "Seconds": {                                     "en": "Seconds",                                         "de": "Sekunden",                                        "ru": "секунд",                                          "pt": "Segundos",                                        "nl": "Seconden",                                        "fr": "Secondes",                                        "it": "secondi",                                         "es": "Segundos",                                        "pl": "sekundy",                                         "zh-cn": "秒"},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.logparser",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -895,9 +895,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.32.tgz",
-      "integrity": "sha512-44/reuCrwiQEsXud3I5X3sqI5jIXAmHB5xoiyKUw965olNHF3IWKjBLKK3F9LOSUZmK+oDt8jmyO637iX+hMgA==",
+      "version": "12.12.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+      "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g==",
       "dev": true
     },
     "@types/proxyquire": {
@@ -913,9 +913,9 @@
       "dev": true
     },
     "@types/sinon-chai": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
-      "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+      "integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
       "dev": true,
       "requires": {
         "@types/chai": "*",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.32",
+    "@types/node": "^12.12.34",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.2",
-    "@types/sinon-chai": "^3.2.3",
+    "@types/sinon-chai": "^3.2.4",
     "axios": "^0.19.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -37,8 +37,8 @@
     "gulp": "^4.0.2",
     "mocha": "^7.1.1",
     "proxyquire": "^2.1.3",
-    "sinon-chai": "^3.5.0",
-    "sinon": "^8.1.1"
+    "sinon": "^8.1.1",
+    "sinon-chai": "^3.5.0"
   },
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
First translations added to word.js

In addition I also uploaded the i18n translation folders.
As you see in my commit, you can. implement translations by : 

- Keeping names/values in index_m.html in English
https://github.com/DutchmanNL/ioBroker.logparser/commit/ab79e570cb81a74fbf3ec29d96e39f0ffa702a51#diff-dbd24f3d81a84911215cdeecdc094a46R297
- You already use the "<translate>" class, meaning iobroker will lookup the value in words.js
- translations are written in words.js, the index = equal value in index_m.html
https://github.com/DutchmanNL/ioBroker.logparser/commit/ab79e570cb81a74fbf3ec29d96e39f0ffa702a51#diff-69bf5f6bfc54c31f00b8a3615f273179R5-R9
- I use gulp to automatically handle translations of i18n\en\translations.json to all other languages

1) Write your code, add/within <class "translate">value
2) Value = index at words.js
3) add your value to i18n\en\translations.json
```
"value": "value"
```
https://github.com/DutchmanNL/ioBroker.logparser/commit/ab79e570cb81a74fbf3ec29d96e39f0ffa702a51#diff-509edb1921ba50b9510c77e8d6627fa7R2-R6
4) run gulp translateAndUpdateWordsJS
5) gulp will translate all new entry's of i18n\en\translations.json into words.js
https://github.com/DutchmanNL/ioBroker.logparser/commit/ab79e570cb81a74fbf3ec29d96e39f0ffa702a51#diff-69bf5f6bfc54c31f00b8a3615f273179R5-R9
6) gulp can also. be used to translate the io-package.json, you only need to add the English part within the news section

reference : https://forum.iobroker.net/topic/19047/gulp-ist-kein-hexenwerk-auto-translation

Have fun!